### PR TITLE
Update dependencies to the latest version and changed deprecated methods to their replacement

### DIFF
--- a/src/dart_snippets/architecture/providers.ts
+++ b/src/dart_snippets/architecture/providers.ts
@@ -13,19 +13,19 @@ import '../core/services/navigator_service.dart';
 import 'package:provider/provider.dart';
 
 class ProviderInjector {
-  static List<SingleChildCloneableWidget> providers = [
+  static List<SingleChildWidget> providers = [
     ..._independentServices,
     ..._dependentServices,
     ..._consumableServices,
   ];
 
-  static List<SingleChildCloneableWidget> _independentServices = [
+  static List<SingleChildWidget> _independentServices = [
     Provider.value(value: locator<NavigatorService>()),
   ];
 
-  static List<SingleChildCloneableWidget> _dependentServices = [];
+  static List<SingleChildWidget> _dependentServices = [];
   
-  static List<SingleChildCloneableWidget> _consumableServices = [];
+  static List<SingleChildWidget> _consumableServices = [];
 }`;
   }
 

--- a/src/dart_snippets/views/desktop.ts
+++ b/src/dart_snippets/views/desktop.ts
@@ -57,7 +57,7 @@ class _HomeDesktop extends StatelessWidget {
             ),
             Text(
               '\${viewModel.counter}',
-              style: Theme.of(context).textTheme.display1,
+              style: Theme.of(context).textTheme.headline4,
             ),
           ],
         ),

--- a/src/dart_snippets/views/mobile.ts
+++ b/src/dart_snippets/views/mobile.ts
@@ -57,7 +57,7 @@ class _HomeMobile extends StatelessWidget {
             ),
             Text(
               '\${viewModel.counter}',
-              style: Theme.of(context).textTheme.display1,
+              style: Theme.of(context).textTheme.headline4,
             ),
           ],
         ),

--- a/src/dart_snippets/views/mobile.ts
+++ b/src/dart_snippets/views/mobile.ts
@@ -45,7 +45,7 @@ class _HomeMobile extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text('Mobile'),
-        backgroundColor: Colors.black,
+        backgroundColor: Colors.green,
       ),
       body: Center(
         child: Column(

--- a/src/dart_snippets/views/mobile.ts
+++ b/src/dart_snippets/views/mobile.ts
@@ -65,7 +65,7 @@ class _HomeMobile extends StatelessWidget {
       floatingActionButton: FloatingActionButton(
         child: Icon(Icons.add),
         onPressed: viewModel.increment,
-        backgroundColor: Colors.black,
+        backgroundColor: Colors.green,
       ),
     );
   }

--- a/src/dart_snippets/views/tablet.ts
+++ b/src/dart_snippets/views/tablet.ts
@@ -57,7 +57,7 @@ class _HomeTablet extends StatelessWidget {
             ),
             Text(
               '\${viewModel.counter}',
-              style: Theme.of(context).textTheme.display1,
+              style: Theme.of(context).textTheme.headline4,
             ),
           ],
         ),

--- a/src/dart_snippets/views/view.ts
+++ b/src/dart_snippets/views/view.ts
@@ -14,7 +14,7 @@ export class View extends Base {
 
     this._dartString = `library ${fileName}_view;
 
-import 'package:provider_architecture/provider_architecture.dart';
+import 'package:stacked/stacked.dart';
 import 'package:responsive_builder/responsive_builder.dart';
 import 'package:flutter/material.dart';
 import '${fileName}_view_model.dart';
@@ -27,7 +27,7 @@ class ${this.className} extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     ${classPrefix}ViewModel viewModel = ${classPrefix}ViewModel();
-    return ViewModelProvider<${classPrefix}ViewModel>.withConsumer(
+    return ViewModelBuilder<${classPrefix}ViewModel>.reactive(
       viewModelBuilder: () => viewModel,
       onModelReady: (viewModel) {
         // Do something once your viewModel is initialized

--- a/src/dart_snippets/views/view.ts
+++ b/src/dart_snippets/views/view.ts
@@ -28,7 +28,7 @@ class ${this.className} extends StatelessWidget {
   Widget build(BuildContext context) {
     ${classPrefix}ViewModel viewModel = ${classPrefix}ViewModel();
     return ViewModelProvider<${classPrefix}ViewModel>.withConsumer(
-      viewModel: viewModel,
+      viewModelBuilder: () => viewModel,
       onModelReady: (viewModel) {
         // Do something once your viewModel is initialized
       },

--- a/src/utils/yaml_helper.ts
+++ b/src/utils/yaml_helper.ts
@@ -7,12 +7,12 @@ export class YamlHelper {
 
     public static initializeWithDependencies() {
         this.upgradeDartVersion();
-        this.addDependencyToPubspec('provider_architecture', '1.0.3');
-        this.addDependencyToPubspec('responsive_builder', '0.1.4');
-        this.addDependencyToPubspec('provider', '3.2.0');
-        this.addDependencyToPubspec('logger', '0.7.0+2');
-        this.addDependencyToPubspec('get_it', '3.0.3');
-        this.addDependencyToPubspec('equatable', '1.0.1');
+        this.addDependencyToPubspec('stacked', '1.5.7+1');
+        this.addDependencyToPubspec('responsive_builder', '0.2.0+2');
+        this.addDependencyToPubspec('provider', '4.1.3');
+        this.addDependencyToPubspec('logger', '0.9.1');
+        this.addDependencyToPubspec('get_it', '4.0.2');
+        this.addDependencyToPubspec('equatable', '1.2.0');
         this.addAssetComment();
     }
 


### PR DESCRIPTION
Replacement due to the warning below:

> 'display1' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline4. This feature was deprecated after v1.13.8..
> Try replacing the use of the deprecated member with the replacement.

I also change the mobile color from black to green. I found that black is the same for the AppBar and the StatusBar and it looks strange that way. Check the images below.

Before:
![Screenshot_1589386635](https://user-images.githubusercontent.com/6011385/81838155-22947900-951c-11ea-8626-d6885bce2a4e.png)
After:
![Screenshot_1589386642](https://user-images.githubusercontent.com/6011385/81838158-23c5a600-951c-11ea-974c-743ac3cd1f65.png)
